### PR TITLE
feat: hot swap controller and joystick support

### DIFF
--- a/app/src/main/java/io/github/arkosammy12/jemu/app/adapters/GameBoyAdapter.java
+++ b/app/src/main/java/io/github/arkosammy12/jemu/app/adapters/GameBoyAdapter.java
@@ -1,6 +1,7 @@
 package io.github.arkosammy12.jemu.app.adapters;
 
 import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.components.XInput;
 import io.github.arkosammy12.jemu.app.io.initializers.CoreInitializer;
 import io.github.arkosammy12.jemu.app.util.System;
 import io.github.arkosammy12.jemu.core.common.Emulator;
@@ -84,7 +85,24 @@ public class GameBoyAdapter extends AbstractSystemAdapter implements GameBoyHost
     @Override
     @Nullable
     public GameBoyJoypad.Actions getActionForJoypadEvent(InputComponent.ID id) {
-        return null;
+        if (id == XInput.DPAD_UP)
+            return GameBoyJoypad.Actions.UP;
+        else if (id == XInput.DPAD_DOWN)
+            return GameBoyJoypad.Actions.DOWN;
+        else if (id == XInput.DPAD_LEFT)
+            return GameBoyJoypad.Actions.LEFT;
+        else if (id == XInput.DPAD_RIGHT)
+            return GameBoyJoypad.Actions.RIGHT;
+        else if (id == XInput.START)
+            return GameBoyJoypad.Actions.START;
+        else if (id == XInput.BACK)
+            return GameBoyJoypad.Actions.SELECT;
+        else if (id == XInput.A)
+            return GameBoyJoypad.Actions.A;
+        else if (id == XInput.X)
+            return GameBoyJoypad.Actions.B;
+        else
+            return null;
     }
 
     @Override

--- a/app/src/main/java/io/github/arkosammy12/jemu/app/drivers/JoypadDriver.java
+++ b/app/src/main/java/io/github/arkosammy12/jemu/app/drivers/JoypadDriver.java
@@ -1,6 +1,7 @@
 package io.github.arkosammy12.jemu.app.drivers;
 
 import de.gurkenlabs.input4j.InputComponent;
+import de.gurkenlabs.input4j.InputDevice;
 import io.github.arkosammy12.jemu.app.util.MavenProperties;
 import io.github.arkosammy12.jemu.app.adapters.AbstractSystemAdapter;
 
@@ -8,8 +9,24 @@ import de.gurkenlabs.input4j.InputDevices;
 import de.gurkenlabs.input4j.components.XInput;
 import io.github.arkosammy12.jemu.core.common.SystemController;
 
-public class JoypadDriver implements AutoCloseable {
+import java.io.IOException;
 
+public class JoypadDriver implements AutoCloseable {
+    private static final int POLL_DEVICES_SLEEP_TIME_MS = 1000; // 1 second
+    private static final int POLL_DEVICE_SLEEP_TIME_MS = 16/2;  // ~1/2 frame
+
+    private static float JOYSTICK_ENGAGED_THRESH = 0.5f;
+
+    // Keep JOYSTICK_DISENGAGED_THRESH <= JOYSTICK_ENGAGED_THRESH.
+    // If JOYSTICK_DISENGAGED_THRESH < JOYSTICK_ENGAGED_THRESH there is a hysteresis effect which seems more natural
+    // when using a joystick in place of a DPAD
+    private static float JOYSTICK_DISENGAGED_THRESH = 0.45f;
+    private boolean joyUp = false;
+    private boolean joyDown = false;
+    private boolean joyLeft = false;
+    private boolean joyRight = false;
+
+    private InputDevice device;
     private final Thread pollThread;
     private volatile boolean running = true;
 
@@ -39,44 +56,120 @@ public class JoypadDriver implements AutoCloseable {
             systemAdapter.getEmulator().getSystemController().onActionReleased(action);
     }
 
+    private void xAxisChange(float val) {
+        if(val >= JOYSTICK_ENGAGED_THRESH && !joyRight){
+            joyRight = true;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_RIGHT);
+            systemAdapter.getEmulator().getSystemController().onActionPressed(action);
+        }
+        else if (val < JOYSTICK_DISENGAGED_THRESH && joyRight){
+            joyRight = false;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_RIGHT);
+            systemAdapter.getEmulator().getSystemController().onActionReleased(action);
+        }
+
+        if(val <= -JOYSTICK_ENGAGED_THRESH && !joyLeft){
+            joyLeft = true;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_LEFT);
+            systemAdapter.getEmulator().getSystemController().onActionPressed(action);
+        }
+        else if (val > -JOYSTICK_DISENGAGED_THRESH && joyLeft){
+            joyLeft = false;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_LEFT);
+            systemAdapter.getEmulator().getSystemController().onActionReleased(action);
+        }
+    }
+
+    private void yAxisChange(float val) {
+        if(val >= JOYSTICK_ENGAGED_THRESH && !joyUp){
+            joyUp = true;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_UP);
+            systemAdapter.getEmulator().getSystemController().onActionPressed(action);
+        }
+        else if (val < JOYSTICK_DISENGAGED_THRESH && joyUp){
+            joyUp = false;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_UP);
+            systemAdapter.getEmulator().getSystemController().onActionReleased(action);
+        }
+
+        if(val <= -JOYSTICK_ENGAGED_THRESH && !joyDown){
+            joyDown = true;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_DOWN);
+            systemAdapter.getEmulator().getSystemController().onActionPressed(action);
+        }
+        else if (val > -JOYSTICK_DISENGAGED_THRESH && joyDown){
+            joyDown = false;
+            SystemController.Action action = systemAdapter.getActionForJoypadEvent(XInput.DPAD_DOWN);
+            systemAdapter.getEmulator().getSystemController().onActionReleased(action);
+        }
+    }
+
+    private void threadSleep(long ms)
+    {
+        try{
+            Thread.sleep(POLL_DEVICE_SLEEP_TIME_MS);
+        } catch (InterruptedException e) {
+            running = false;
+            Thread.currentThread().interrupt();
+        }
+    }
+
     private void pollLoop() {
-        var devices = InputDevices.init();
-
-        // For now, only support controllers connected at application start
-        if(devices.getAll().isEmpty())
-            return;
-
-        var device = devices.getAll().iterator().next();
-
-        device.onButtonPressed(XInput.DPAD_UP, () -> pressButton(XInput.DPAD_UP));
-        device.onButtonPressed(XInput.DPAD_DOWN, () -> pressButton(XInput.DPAD_DOWN));
-        device.onButtonPressed(XInput.DPAD_LEFT, () -> pressButton(XInput.DPAD_LEFT));
-        device.onButtonPressed(XInput.DPAD_RIGHT, () -> pressButton(XInput.DPAD_RIGHT));
-        device.onButtonPressed(XInput.START, () -> pressButton(XInput.START));
-        device.onButtonPressed(XInput.BACK, () -> pressButton(XInput.BACK));
-        device.onButtonPressed(XInput.X, () -> pressButton(XInput.X));
-        device.onButtonPressed(XInput.A, () -> pressButton(XInput.A));
-
-        device.onButtonReleased(XInput.DPAD_UP, () -> releaseButton(XInput.DPAD_UP));
-        device.onButtonReleased(XInput.DPAD_DOWN, () -> releaseButton(XInput.DPAD_DOWN));
-        device.onButtonReleased(XInput.DPAD_LEFT, () -> releaseButton(XInput.DPAD_LEFT));
-        device.onButtonReleased(XInput.DPAD_RIGHT, () -> releaseButton(XInput.DPAD_RIGHT));
-        device.onButtonReleased(XInput.START, () -> releaseButton(XInput.START));
-        device.onButtonReleased(XInput.BACK, () -> releaseButton(XInput.BACK));
-        device.onButtonReleased(XInput.X, () -> releaseButton(XInput.X));
-        device.onButtonReleased(XInput.A, () -> releaseButton(XInput.A));
-
         while (running)
         {
-            device.poll();
+            try (var devices = InputDevices.init()) {
+                // For some reason the onDeviceConnected event doesn't work as a hot swap so is rather useless...
+                // We must call InputDevices.init() to check for newly connected controllers
+                devices.onDeviceDisconnected(this::detachDevice);
+                devices.getAll().stream().findFirst().ifPresent(this::attachDevice);
 
-            try{
-                Thread.sleep(5); // test
-            } catch (InterruptedException e) {
-                running = false;
-                Thread.currentThread().interrupt();
+                while(running && device != null)
+                {
+                    device.poll();
+                    threadSleep(POLL_DEVICE_SLEEP_TIME_MS);
+                }
+            } catch (IOException e) {
+                // Do nothing; loop will re-initialize
             }
+
+            threadSleep(POLL_DEVICES_SLEEP_TIME_MS);
         }
+    }
+
+    private void detachDevice(InputDevice inputDevice) {
+        // TODO: multiple controller support
+        if (this.device == inputDevice) {
+            this.device = null;
+        }
+    }
+
+    private void attachDevice(InputDevice inputDevice) {
+        // TODO: multiple controller support
+        if (this.device != null)
+            return;
+
+        this.device = inputDevice;
+
+        this.device.onButtonPressed(XInput.DPAD_UP, () -> pressButton(XInput.DPAD_UP));
+        this.device.onButtonPressed(XInput.DPAD_DOWN, () -> pressButton(XInput.DPAD_DOWN));
+        this.device.onButtonPressed(XInput.DPAD_LEFT, () -> pressButton(XInput.DPAD_LEFT));
+        this.device.onButtonPressed(XInput.DPAD_RIGHT, () -> pressButton(XInput.DPAD_RIGHT));
+        this.device.onButtonPressed(XInput.START, () -> pressButton(XInput.START));
+        this.device.onButtonPressed(XInput.BACK, () -> pressButton(XInput.BACK));
+        this.device.onButtonPressed(XInput.X, () -> pressButton(XInput.X));
+        this.device.onButtonPressed(XInput.A, () -> pressButton(XInput.A));
+
+        this.device.onButtonReleased(XInput.DPAD_UP, () -> releaseButton(XInput.DPAD_UP));
+        this.device.onButtonReleased(XInput.DPAD_DOWN, () -> releaseButton(XInput.DPAD_DOWN));
+        this.device.onButtonReleased(XInput.DPAD_LEFT, () -> releaseButton(XInput.DPAD_LEFT));
+        this.device.onButtonReleased(XInput.DPAD_RIGHT, () -> releaseButton(XInput.DPAD_RIGHT));
+        this.device.onButtonReleased(XInput.START, () -> releaseButton(XInput.START));
+        this.device.onButtonReleased(XInput.BACK, () -> releaseButton(XInput.BACK));
+        this.device.onButtonReleased(XInput.X, () -> releaseButton(XInput.X));
+        this.device.onButtonReleased(XInput.A, () -> releaseButton(XInput.A));
+
+        this.device.onAxisChanged(XInput.LEFT_THUMB_X, this::xAxisChange);
+        this.device.onAxisChanged(XInput.LEFT_THUMB_Y, this::yAxisChange);
     }
 
     @Override


### PR DESCRIPTION
Adds support for connecting a controller after app has started - including disconnect/re-connect.
Adds joystick DPAD emulation.
Adds gameboy joypad actions.