### PR TITLE
Stage CPU bus access at specific dot within an mcycle

### DIFF
--- a/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
@@ -837,9 +837,9 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                     switch (machineCycleIndex) {
                         case 0 -> {
                             if (interruptsPending()) {
-                                if (!getIME()) {
+                                //if (!getIME()) {
                                     this.haltBug = true;
-                                }
+                                //}
                                 machineCycleIndex = TERMINATE_INSTRUCTION;
                             } else {
                                 this.mode = Mode.HALTED;

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
@@ -843,7 +843,9 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                     switch (machineCycleIndex) {
                         case 0 -> {
                             if (interruptsPending()) {
-                                this.haltBug = true;
+                                if (!getIME()) {
+                                    this.haltBug = true;
+                                }
                                 machineCycleIndex = TERMINATE_INSTRUCTION;
                             } else {
                                 this.mode = Mode.HALTED;

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/cpu/SM83.java
@@ -291,7 +291,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
         if (this.machineCycleIndex < 0) {
             setIR(this.systemBus.getBus().readByte(getPC()));
             if (!this.haltBug) {
-                systemBus.onIDURead(getPC());
                 setPC(getPC() + 1);
             }
             this.haltBug = false;
@@ -558,7 +557,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                         switch (machineCycleIndex) {
                                             case 0 -> {
                                                 systemBus.getBus().writeByte(getHL(), getA());
-                                                systemBus.onIDUWrite(getHL());
                                                 setHL(getHL() + 1);
                                                 machineCycleIndex = 1;
                                             }
@@ -571,7 +569,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                         switch (machineCycleIndex) {
                                             case 0 -> {
                                                 systemBus.getBus().writeByte(getHL(), getA());
-                                                systemBus.onIDUWrite(getHL());
                                                 setHL(getHL() - 1);
                                                 machineCycleIndex = 1;
                                             }
@@ -612,7 +609,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                         switch (machineCycleIndex) {
                                             case 0 -> {
                                                 setZ(systemBus.getBus().readByte(getHL()));
-                                                systemBus.onIDURead(getHL());
                                                 setHL(getHL() + 1);
                                                 machineCycleIndex = 1;
                                             }
@@ -626,7 +622,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                         switch (machineCycleIndex) {
                                             case 0 -> {
                                                 setZ(systemBus.getBus().readByte(getHL()));
-                                                systemBus.onIDURead(getHL());
                                                 setHL(getHL() - 1);
                                                 machineCycleIndex = 1;
                                             }
@@ -678,7 +673,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                 case 1 -> {
                                     int result = getZ() + 1;
                                     this.systemBus.getBus().writeByte(getHL(), result);
-                                    systemBus.onIDUWrite(getZ());
                                     setFZ((result & 0xFF) == 0);
                                     setFN(false);
                                     setFH((getZ() & 0xF) + 1 > 0xF);
@@ -1157,13 +1151,11 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                 switch (machineCycleIndex) {
                                     case 0 -> {
                                         setZ(systemBus.getBus().readByte(getSP()));
-                                        systemBus.onIDURead(getSP());
                                         setSP(getSP() + 1);
                                         machineCycleIndex = 1;
                                     }
                                     case 1 -> {
                                         setW(systemBus.getBus().readByte(getSP()));
-                                        systemBus.onIDURead(getSP());
                                         setSP(getSP() + 1);
                                         machineCycleIndex = 2;
                                     }
@@ -1416,7 +1408,6 @@ public class SM83<S extends SM83.SystemBus> implements Processor {
                                     }
                                     case 1 -> {
                                         systemBus.getBus().writeByte(getSP(), (getRP2(p) & 0xFF00) >>> 8);
-                                        systemBus.onIDUWrite(getSP());
                                         setSP(getSP() - 1);
                                         machineCycleIndex = 2;
                                     }

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
@@ -122,6 +122,9 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
 
     @Override
     public int readByte(int address) {
+        // The address is on the bus from the start of the M-cycle, before this
+        // M-cycle's dots run
+        this.emulator.getVideoGenerator().checkArmOAMBugRead(address);
         this.emulator.syncPpuForCpuRead();
         if (this.isOAMDMABusConflict(address)) {
             // TODO: Perhaps this value is only returned when reading from OAM. Otherwise return the current value being read by OAM. Check numism test ROM for info.
@@ -166,6 +169,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
 
     @Override
     public void writeByte(int address, int value) {
+        this.emulator.getVideoGenerator().checkArmOAMBugWrite(address);
         if ((address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR)) {
             this.emulator.syncPpuForCpuPpuRegisterWrite();
         }

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
@@ -122,6 +122,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
 
     @Override
     public int readByte(int address) {
+        this.emulator.syncPpuForCpuRead();
         if (this.isOAMDMABusConflict(address)) {
             // TODO: Perhaps this value is only returned when reading from OAM. Otherwise return the current value being read by OAM. Check numism test ROM for info.
             return 0xFF;
@@ -165,6 +166,9 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
 
     @Override
     public void writeByte(int address, int value) {
+        if ((address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR)) {
+            this.emulator.syncPpuForCpuPpuRegisterWrite();
+        }
         if (this.oamTransferInProgress && address < 0xFF00) {
             return;
         }

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
@@ -76,9 +76,9 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
     private int interruptEnable;
 
     private int oamDmaControl;
-    private int oamTransferDelay;
-    protected boolean oamTransferInProgress;
-    private int oamTransferredBytes;
+    private int oamDmaStartDelay;
+    protected boolean oamDmaInProgress;
+    private int oamDmaTransferredBytes;
 
     protected boolean enableBootRom = true;
 
@@ -112,7 +112,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         // The address is on the bus from the start of the M-cycle, before this
         // M-cycle's dots run
         this.emulator.getVideoGenerator().checkArmOAMBugRead(address);
-        this.emulator.syncPpuForCpuRead();
+        this.emulator.syncPPUForCPURead();
         if (this.isOAMDMABusConflict(address)) {
             // TODO: Perhaps this value is only returned when reading from OAM. Otherwise return the current value being read by OAM. Check numism test ROM for info.
             return 0xFF;
@@ -172,10 +172,10 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
 
         this.emulator.getVideoGenerator().checkArmOAMBugWrite(address);
         if (this.isPPURegisterAddress(address)) {
-            this.emulator.syncPpuForCpuPpuRegisterWrite();
+            this.emulator.syncPPUForCPUPPURegisterWrite();
         }
 
-        if (this.oamTransferInProgress && address < 0xFF00) {
+        if (this.oamDmaInProgress && address < 0xFF00) {
             return;
         }
 
@@ -204,7 +204,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         switch (address) {
             case OAM_DMA_ADDR -> {
                 this.oamDmaControl = value & 0xFF;
-                this.oamTransferDelay = 2;
+                this.oamDmaStartDelay = 2;
             }
             case BANK_ADDR -> this.enableBootRom = false;
             case JOYP_ADDR -> this.emulator.getSystemController().writeJoyP(value);
@@ -227,20 +227,20 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
     }
 
     public void cycleOAMDMA() {
-        if (this.oamTransferInProgress) {
-            int sourceAddress = (this.oamDmaControl << 8) | (this.oamTransferredBytes);
+        if (this.oamDmaInProgress) {
+            int sourceAddress = (this.oamDmaControl << 8) | (this.oamDmaTransferredBytes);
             int oamByte = this.readByteOAMDMA(sourceAddress);
-            this.emulator.getVideoGenerator().writeOAMDMA(0xFE00 | this.oamTransferredBytes, oamByte);
-            this.oamTransferredBytes++;
-            if (this.oamTransferredBytes > 0x9F) {
-                this.oamTransferInProgress = false;
+            this.emulator.getVideoGenerator().writeOAMDMA(0xFE00 | this.oamDmaTransferredBytes, oamByte);
+            this.oamDmaTransferredBytes++;
+            if (this.oamDmaTransferredBytes > 0x9F) {
+                this.oamDmaInProgress = false;
             }
         }
-        if (this.oamTransferDelay > 0) {
-            this.oamTransferDelay--;
-            if (this.oamTransferDelay <= 0) {
-                this.oamTransferInProgress = true;
-                this.oamTransferredBytes = 0;
+        if (this.oamDmaStartDelay > 0) {
+            this.oamDmaStartDelay--;
+            if (this.oamDmaStartDelay <= 0) {
+                this.oamDmaInProgress = true;
+                this.oamDmaTransferredBytes = 0;
             }
         }
 
@@ -269,11 +269,11 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
             return false;
         }
         boolean oamBusConflict = false;
-        if (this.oamTransferInProgress) {
+        if (this.oamDmaInProgress) {
             if (address >= OAM_START && address <= OAM_END) {
                 return true;
             }
-            int sourceAddress = (this.oamDmaControl << 8) | (this.oamTransferredBytes);
+            int sourceAddress = (this.oamDmaControl << 8) | (this.oamDmaTransferredBytes);
             if (address >= 0x0000 && address <= 0x7FFF && sourceAddress >= 0x0000 && sourceAddress <= 0x7FFF) { // External bus
                 oamBusConflict = true;
             } else if (address >= 0xA000 && address <= 0xFDFF && sourceAddress >= 0xA000 && sourceAddress <= 0xFDFF) { // External bus

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGBus.java
@@ -48,12 +48,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
     public static final int SRAM_END = 0xBFFF;
 
     public static final int WRAM0_START = 0xC000;
-    public static final int WRAM0_END = 0xCFFF;
-
-    public static final int WRAMX_START = 0xD000;
     public static final int WRAMX_END = 0xDFFF;
-
-    public static final int ECHO_START = 0xE000;
     public static final int ECHO_END = 0xFDFF;
 
     public static final int OAM_START = 0xFE00;
@@ -96,14 +91,6 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         return new byte[1][0x2000];
     }
 
-    protected int readWorkRAM(int address) {
-        return (int) this.workRAM[0][address & 0x1FFF] & 0xFF;
-    }
-
-    protected void writeWorkRAM(int address, int value) {
-        this.workRAM[0][address & 0x1FFF] = (byte) value;
-    }
-
     public boolean isBootRomEnabled() {
         return this.enableBootRom;
     }
@@ -130,11 +117,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
             // TODO: Perhaps this value is only returned when reading from OAM. Otherwise return the current value being read by OAM. Check numism test ROM for info.
             return 0xFF;
         } else if ((address >= ROM0_START && address <= ROMX_END) || (address >= SRAM_START && address <= SRAM_END)) {
-            if (this.enableBootRom && address <= 0x00FF) {
-                return BOOTIX[address];
-            } else {
-                return this.emulator.getCartridge().readByte(address);
-            }
+            return this.readByteCartridge(address);
         } else if ((address >= VRAM_START && address <= VRAM_END) || (address >= OAM_START && address <= OAM_END)) {
             return this.emulator.getVideoGenerator().readByte(address);
         } else if (address >= WRAM0_START && address <= ECHO_END) {
@@ -142,24 +125,7 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         } else if (address >= UNUSED_START && address <= UNUSED_END) {
             return 0x00;
         } else if ((address >= IO_START && address <= IO_END) || address == IE_ADDR) {
-            return switch (address) {
-                case OAM_DMA_ADDR -> this.oamDmaControl;
-                case BANK_ADDR -> (this.enableBootRom ? 0 : 1) | 0b11111110;
-                case JOYP_ADDR -> this.emulator.getSystemController().readJoypad();
-                case SB_ADDR, SC_ADDR -> this.emulator.getSerialController().readByte(address);
-                case DIV_ADDR, TIMA_ADDR, TMA_ADDR, TAC_ADDR -> this.emulator.getTimerController().readByte(address);
-                case IF_ADDR -> this.interruptFlag | 0b11100000;
-                case IE_ADDR -> this.interruptEnable;
-                default -> {
-                    if ((address >= NR10_ADDR && address <= NR14_ADDR) || (address >= NR21_ADDR && address <= NR34_ADDR) || (address >= NR41_ADDR && address <= NR52_ADDR) || (address >= WAVERAM_START && address <= WAVERAM_END)) {
-                        yield this.emulator.getAudioGenerator().readByte(address);
-                    } else if ((address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR)) {
-                        yield this.emulator.getVideoGenerator().readByte(address);
-                    } else {
-                        yield 0xFF;
-                    }
-                }
-            };
+            return this.readByteIO(address);
         } else if (address >= HRAM_START && address <= HRAM_END) {
             return this.emulator.getCpu().readHRAM(address);
         } else {
@@ -167,15 +133,52 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         }
     }
 
+    protected int readByteCartridge(int address) {
+        if (this.enableBootRom && address <= 0x00FF) {
+            return BOOTIX[address];
+        } else {
+            return this.emulator.getCartridge().readByte(address);
+        }
+    }
+
+    protected int readWorkRAM(int address) {
+        return (int) this.workRAM[0][address & 0x1FFF] & 0xFF;
+    }
+
+    protected int readByteIO(int address) {
+        return switch (address) {
+            case OAM_DMA_ADDR -> this.oamDmaControl;
+            case BANK_ADDR -> (this.enableBootRom ? 0 : 1) | 0b11111110;
+            case JOYP_ADDR -> this.emulator.getSystemController().readJoypad();
+            case SB_ADDR, SC_ADDR -> this.emulator.getSerialController().readByte(address);
+            case DIV_ADDR, TIMA_ADDR, TMA_ADDR, TAC_ADDR -> this.emulator.getTimerController().readByte(address);
+            case IF_ADDR -> this.interruptFlag | 0b11100000;
+            case IE_ADDR -> this.interruptEnable;
+            default -> {
+                if ((address >= NR10_ADDR && address <= NR14_ADDR) || (address >= NR21_ADDR && address <= NR34_ADDR) || (address >= NR41_ADDR && address <= NR52_ADDR) || (address >= WAVERAM_START && address <= WAVERAM_END)) {
+                    yield this.emulator.getAudioGenerator().readByte(address);
+                } else if (this.isPPURegisterAddress(address)) {
+                    yield this.emulator.getVideoGenerator().readByte(address);
+                } else {
+                    yield 0xFF;
+                }
+            }
+        };
+    }
+
     @Override
     public void writeByte(int address, int value) {
+        value &= 0xFF;
+
         this.emulator.getVideoGenerator().checkArmOAMBugWrite(address);
-        if ((address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR)) {
+        if (this.isPPURegisterAddress(address)) {
             this.emulator.syncPpuForCpuPpuRegisterWrite();
         }
+
         if (this.oamTransferInProgress && address < 0xFF00) {
             return;
         }
+
         if ((address >= ROM0_START && address <= ROMX_END) || (address >= SRAM_START && address <= SRAM_END)) {
             this.emulator.getCartridge().writeByte(address, value);
         } else if ((address >= VRAM_START && address <= VRAM_END) || (address >= OAM_START && address <= OAM_END)) {
@@ -183,32 +186,44 @@ public class DMGBus<E extends GameBoyEmulator> implements Bus {
         } else if (address >= WRAM0_START && address <= ECHO_END) {
             this.writeWorkRAM(address, value);
         } else if (address >= UNUSED_START && address <= UNUSED_END) {
-            // TODO: TRIGGER OAM BUG
+
         } else if ((address >= IO_START && address <= IO_END) || address == IE_ADDR) {
-            switch (address) {
-                case OAM_DMA_ADDR -> {
-                    this.oamDmaControl = value & 0xFF;
-                    this.oamTransferDelay = 2;
-                }
-                case BANK_ADDR -> this.enableBootRom = false;
-                case JOYP_ADDR -> this.emulator.getSystemController().writeJoyP(value);
-                case SB_ADDR, SC_ADDR -> this.emulator.getSerialController().writeByte(address, value);
-                case DIV_ADDR, TIMA_ADDR, TMA_ADDR, TAC_ADDR -> this.emulator.getTimerController().writeByte(address, value);
-                case IF_ADDR -> this.interruptFlag = value & 0xFF; // TODO: If the CPU clears a bit on the same cycle that a component tries setting the bit, the bit says cleared!
-                case IE_ADDR -> this.interruptEnable = value & 0xFF;
-                default -> {
-                    if ((address >= NR10_ADDR && address <= NR14_ADDR) || (address >= NR21_ADDR && address <= NR34_ADDR) || (address >= NR41_ADDR && address <= NR52_ADDR) || (address >= WAVERAM_START && address <= WAVERAM_END)) {
-                        this.emulator.getAudioGenerator().writeByte(address, value);
-                    } else if ((address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR)) {
-                        this.emulator.getVideoGenerator().writeByte(address, value);
-                    }
-                }
-            }
+            this.writeByteIO(address, value);
         } else if (address >= HRAM_START && address <= HRAM_END) {
             this.emulator.getCpu().writeHRAM(address, value);
         } else {
             throw new EmulatorException("Invalid GameBoy memory address $%04X!".formatted(address));
         }
+    }
+
+    protected void writeWorkRAM(int address, int value) {
+        this.workRAM[0][address & 0x1FFF] = (byte) value;
+    }
+
+    protected void writeByteIO(int address, int value) {
+        switch (address) {
+            case OAM_DMA_ADDR -> {
+                this.oamDmaControl = value & 0xFF;
+                this.oamTransferDelay = 2;
+            }
+            case BANK_ADDR -> this.enableBootRom = false;
+            case JOYP_ADDR -> this.emulator.getSystemController().writeJoyP(value);
+            case SB_ADDR, SC_ADDR -> this.emulator.getSerialController().writeByte(address, value);
+            case DIV_ADDR, TIMA_ADDR, TMA_ADDR, TAC_ADDR -> this.emulator.getTimerController().writeByte(address, value);
+            case IF_ADDR -> this.interruptFlag = value & 0xFF; // TODO: If the CPU clears a bit on the same cycle that a component tries setting the bit, the bit says cleared!
+            case IE_ADDR -> this.interruptEnable = value & 0xFF;
+            default -> {
+                if ((address >= NR10_ADDR && address <= NR14_ADDR) || (address >= NR21_ADDR && address <= NR34_ADDR) || (address >= NR41_ADDR && address <= NR52_ADDR) || (address >= WAVERAM_START && address <= WAVERAM_END)) {
+                    this.emulator.getAudioGenerator().writeByte(address, value);
+                } else if (this.isPPURegisterAddress(address)) {
+                    this.emulator.getVideoGenerator().writeByte(address, value);
+                }
+            }
+        }
+    }
+
+    protected boolean isPPURegisterAddress(int address) {
+        return (address >= LCDC_ADDR && address <= LYC_ADDR) || (address >= BGP_ADDR && address <= WX_ADDR);
     }
 
     public void cycleOAMDMA() {

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
@@ -114,13 +114,13 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     protected int spriteFifoTileDataLow;
     protected int spriteFifoTileDataHigh;
 
-    private boolean armOamBugRead;
-    private boolean armOamBugWrite;
+    private boolean armOAMBugRead;
+    private boolean armOAMBugWrite;
 
     public DMGPPU(E emulator) {
         super(emulator);
         this.lcd = new int[this.getImageWidth() * this.getImageHeight()];
-        Arrays.fill(this.lcd, this.getLcdOffColor());
+        Arrays.fill(this.lcd, this.getLCDOffColor());
         Arrays.fill(this.spriteBuffer, -1);
     }
 
@@ -134,7 +134,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         return HEIGHT;
     }
 
-    protected int getLcdOffColor() {
+    protected int getLCDOffColor() {
         return 0x9BBC0F;
     }
 
@@ -242,13 +242,13 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
 
     public void checkArmOAMBugRead(int address) {
         if (address >= OAM_START && address <= UNUSED_END && this.getLCDPPUEnable()) {
-            this.armOamBugRead = true;
+            this.armOAMBugRead = true;
         }
     }
 
     public void checkArmOAMBugWrite(int address) {
         if (address >= OAM_START && address <= UNUSED_END && this.getLCDPPUEnable()) {
-            this.armOamBugWrite = true;
+            this.armOAMBugWrite = true;
         }
     }
 
@@ -263,17 +263,10 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         this.enablePixelWritesDelay = -1;
         this.lcdOnLine = false;
         this.pendingVisibleMode = -1;
-        this.armOamBugRead = false;
-        this.armOamBugWrite = false;
-        Arrays.fill(this.lcd, this.getLcdOffColor());
+        this.armOAMBugRead = false;
+        this.armOAMBugWrite = false;
+        Arrays.fill(this.lcd, this.getLCDOffColor());
         this.emulator.getHost().getVideoDriver().ifPresent(driver -> driver.outputFrame(this.lcd));
-    }
-
-    public void cycle() {
-        this.cycleDot(0);
-        this.cycleDot(1);
-        this.cycleDot(2);
-        this.cycleDot(3);
     }
 
     void cycleDot(int tCycle) {
@@ -301,13 +294,13 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         }
 
         if (tCycle == 2) {
-            if (this.armOamBugRead) {
+            if (this.armOAMBugRead) {
                 this.doOAMBugRead();
-            } else if (this.armOamBugWrite) {
+            } else if (this.armOAMBugWrite) {
                 this.doOAMBugWrite();
             }
-            this.armOamBugRead = false;
-            this.armOamBugWrite = false;
+            this.armOAMBugRead = false;
+            this.armOAMBugWrite = false;
         }
 
         this.dotNumber++;
@@ -375,7 +368,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
             // The mode-bit bus drivers settle in about a dot and a half: a transition
             // early in the M-cycle is visible to a read latching at its end, a later
             // one only from the next M-cycle
-            if (this.emulator.mcycleDot <= 1) {
+            if (this.emulator.mCycleDot <= 1) {
                 this.setPPUMode(this.currentMode.getValue());
             } else {
                 this.pendingVisibleMode = this.currentMode.getValue();

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
@@ -142,10 +142,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     public int readByte(int address) {
         if (address >= OAM_START && address <= OAM_END) {
             int ppuMode = this.getPPUMode();
-
-            // TODO: Reincorporate when corruption pattern and timings are correct
-            //this.checkArmOAMBugRead(address);
-
             if (Mode.MODE_0_HBLANK.matchesValue(ppuMode) || Mode.MODE_1_VBLANK.matchesValue(ppuMode) || !this.getLCDPPUEnable()) {
                 return (int) this.oam[address - OAM_START] & 0xFF;
             } else {
@@ -180,10 +176,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     public void writeByte(int address, int value) {
         if (address >= OAM_START && address <= OAM_END) {
             int ppuMode = this.getPPUMode();
-
-            // TODO: Reincorporate when corruption pattern and timings are correct
-            //this.checkArmOAMBugWrite(address);
-
             if (Mode.MODE_0_HBLANK.matchesValue(ppuMode) || Mode.MODE_1_VBLANK.matchesValue(ppuMode) || !this.getLCDPPUEnable()) {
               this.oam[address - OAM_START] = (byte) value;
             }
@@ -527,7 +519,12 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     }
 
     protected void doOAMBugRead() {
-        int cur = ((this.scannedEntries / 2) + 1) * 8;
+        // The scanner reaches its first entry 4 dots into Mode 2, two entries behind
+        // the scan counter
+        int cur = ((Math.max(this.scannedEntries - 2, 0) / 2) + 1) * 8;
+        if (this.scannedEntries < 2) {
+            return;
+        }
         if (cur < 8 || cur >= 160 || !Mode.MODE_2_OAM_SCAN.matchesValue(this.getPPUMode())) {
             return;
         }
@@ -582,7 +579,10 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     }
 
     protected void doOAMBugWrite() {
-        int cur = ((this.scannedEntries / 2) + 1) * 8;
+        int cur = ((Math.max(this.scannedEntries - 2, 0) / 2) + 1) * 8;
+        if (this.scannedEntries < 2) {
+            return;
+        }
         if (cur < 8 || cur >= 160 || !Mode.MODE_2_OAM_SCAN.matchesValue(this.getPPUMode())) {
             return;
         }

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
@@ -80,6 +80,9 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
 
     protected boolean enablePixelWrites;
     private int enablePixelWritesDelay;
+    private boolean lcdOnLine;
+    private int pendingVisibleMode = -1;
+    private boolean pendingLyIncrement;
 
     private boolean oldStatInterruptLine;
 
@@ -259,12 +262,15 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
 
     private void onLCDOn() {
         this.enablePixelWritesDelay = 2;
-        this.dotNumber = 4;
+        this.dotNumber = 2;
+        this.lcdOnLine = true;
     }
 
     private void onLCDOff() {
         this.enablePixelWrites = false;
         this.enablePixelWritesDelay = -1;
+        this.lcdOnLine = false;
+        this.pendingVisibleMode = -1;
         this.armOamBugRead = false;
         this.armOamBugWrite = false;
         Arrays.fill(this.lcd, this.getLcdOffColor());
@@ -278,9 +284,20 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         this.cycleDot(3);
     }
 
-    private void cycleDot(int tCycle) {
+    void cycleDot(int tCycle) {
         if (!this.getLCDPPUEnable()) {
             return;
+        }
+        // STAT mode bits latched by a CPU read in the same M-cycle as a mode transition
+        // show the pre-transition value; publish at the next M-cycle boundary
+        if (tCycle == 0 && this.pendingVisibleMode >= 0) {
+            this.setPPUMode(this.pendingVisibleMode);
+            this.pendingVisibleMode = -1;
+        }
+        // LY ripples one dot after the scanline wrap
+        if (this.pendingLyIncrement) {
+            this.lcdY = (this.lcdY + 1) % SCANLINES_PER_FRAME;
+            this.pendingLyIncrement = false;
         }
         this.nextState();
 
@@ -302,14 +319,17 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         }
 
         this.dotNumber++;
-        if (this.dotNumber >= CYCLES_PER_SCANLINE) {
+        // The first scanline after LCD-on is 454 dots, its Mode 0 ending early
+        int lineLength = this.lcdOnLine ? CYCLES_PER_SCANLINE - 2 : CYCLES_PER_SCANLINE;
+        if (this.dotNumber >= lineLength) {
+            this.lcdOnLine = false;
             this.dotNumber = 0;
             this.dotCycleIndex = 0;
 
             int originalScanlineNumber = this.scanlineNumber;
             this.scanlineNumber = (this.scanlineNumber + 1) % SCANLINES_PER_FRAME;
             if (originalScanlineNumber != 153) {
-                this.lcdY = (this.lcdY + 1) % SCANLINES_PER_FRAME;
+                this.pendingLyIncrement = true;
                 this.setLYEqualsLYCFlag(false);
             }
 
@@ -319,7 +339,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
             }
         }
 
-        if (this.dotNumber >= 3) {
+        if (this.dotNumber >= 1) {
             this.setLYEqualsLYCFlag(this.lcdY == this.lcdYCompare);
         }
 
@@ -345,7 +365,8 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         if (this.dotNumber == 0) {
             if (this.scanlineNumber >= 144) {
                 this.currentMode = Mode.MODE_1_VBLANK;
-            } else {
+            } else if (!this.lcdOnLine) {
+                // OAM scan is skipped on the first scanline after LCD-on
                 this.currentMode = Mode.MODE_2_OAM_SCAN;
             }
         } else if (this.dotNumber == 80) {
@@ -359,6 +380,14 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
         }
         if (oldMode != this.currentMode) {
             this.dotCycleIndex = 0;
+            // The mode-bit bus drivers settle in about a dot and a half: a transition
+            // early in the M-cycle is visible to a read latching at its end, a later
+            // one only from the next M-cycle
+            if (this.emulator.mcycleDot <= 1) {
+                this.setPPUMode(this.currentMode.getValue());
+            } else {
+                this.pendingVisibleMode = this.currentMode.getValue();
+            }
         }
     }
 
@@ -368,15 +397,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 1;
             }
             case 1 -> {
-                this.dotCycleIndex = 2;
-            }
-            case 2 -> {
-                this.dotCycleIndex = 3;
-            }
-            case 3 -> {
                 if (this.scanlineNumber == 144) {
-
-                    this.setPPUMode(Mode.MODE_1_VBLANK.getValue());
                     this.setSTATModeForInterrupt(Mode.MODE_1_VBLANK.getValue());
                     this.triggerVBlankInterrupt();
                     this.windowYCondition = false;
@@ -390,7 +411,14 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                     }
 
                     this.emulator.getHost().getVideoDriver().ifPresent(driver -> driver.outputFrame(this.lcd));
-                } else if (this.scanlineNumber == 153) {
+                }
+                this.dotCycleIndex = 2;
+            }
+            case 2 -> {
+                this.dotCycleIndex = 3;
+            }
+            case 3 -> {
+                if (this.scanlineNumber == 153) {
                     this.lcdY = 0;
                     this.setLYEqualsLYCFlag(false);
                 }
@@ -407,14 +435,13 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 1;
             }
             case 1 -> {
+                this.setSTATModeForInterrupt(Mode.MODE_0_HBLANK.getValue());
                 this.dotCycleIndex = 2;
             }
             case 2 -> {
                 this.dotCycleIndex = 3;
             }
             case 3 -> {
-                this.setSTATModeForInterrupt(Mode.MODE_0_HBLANK.getValue());
-                this.setPPUMode(Mode.MODE_0_HBLANK.getValue());
                 this.dotCycleIndex = 4;
             }
             case 4 -> {}
@@ -459,6 +486,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 1;
             }
             case 1 -> {
+                this.setSTATModeForInterrupt(Mode.MODE_2_OAM_SCAN.getValue());
                 this.tickOAMScan();
                 this.dotCycleIndex = 2;
             }
@@ -466,8 +494,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 3;
             }
             case 3 -> {
-                this.setPPUMode(Mode.MODE_2_OAM_SCAN.getValue());
-                this.setSTATModeForInterrupt(Mode.MODE_2_OAM_SCAN.getValue());
                 this.tickOAMScan();
                 this.dotCycleIndex = 4;
             }
@@ -579,6 +605,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 1;
             }
             case 1 -> {
+                this.setSTATModeForInterrupt(Mode.MODE_3_DRAWING.getValue());
                 this.tickDraw();
                 this.dotCycleIndex = 2;
             }
@@ -587,8 +614,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.dotCycleIndex = 3;
             }
             case 3 -> {
-                this.setPPUMode(Mode.MODE_3_DRAWING.getValue());
-                this.setSTATModeForInterrupt(Mode.MODE_3_DRAWING.getValue());
                 this.tickDraw();
                 this.dotCycleIndex = 4;
             }

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/DMGPPU.java
@@ -39,7 +39,7 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     };
 
     protected final byte[] vram = new byte[0x2000];
-    private final byte[] oam = new byte[0x00A0]; // TODO: OAM BUG (ONLY FOR DMG) GODDAMMIT!
+    private final byte[] oam = new byte[0x00A0];
 
     private int lcdControl;
     private boolean lcdPPUEnable;
@@ -441,7 +441,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
     }
 
     protected void onHBlankStart() {
-
         this.scannedEntries = 0;
 
         this.pixelX = 0;
@@ -485,16 +484,12 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
             case 2 -> {
                 this.dotCycleIndex = 3;
             }
-            case 3 -> {
+            case 3, 5 -> {
                 this.tickOAMScan();
                 this.dotCycleIndex = 4;
             }
             case 4 -> {
                 this.dotCycleIndex = 5;
-            }
-            case 5 -> {
-                this.tickOAMScan();
-                this.dotCycleIndex = 4;
             }
         }
     }
@@ -622,8 +617,6 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
             }
         }
     }
-
-    //private int dotsSpentInSpritePlusStalling;
 
     private void tickDraw() {
         boolean originalWindowCondition = this.isRenderingWindow();
@@ -817,13 +810,9 @@ public class DMGPPU<E extends GameBoyEmulator> extends VideoGenerator<E> impleme
                 this.spriteBuffer[this.spriteFifoCurrentEntryIndex] = -1;
                 this.spriteFifoCurrentEntryIndex = -1;
                 this.spriteFifoStep = 0;
-
-                //this.spriteCount++;
             }
         }
     }
-
-    //protected int spriteCount;
 
     protected void tickPixelShifter() {
         if (this.backgroundFifo.isEmpty()) {

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/GameBoyEmulator.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/GameBoyEmulator.java
@@ -24,7 +24,7 @@ public class GameBoyEmulator implements Emulator, SM83.SystemBus {
 
     private final GameBoyCartridge cartridge;
 
-    protected int mcycleDot;
+    protected int mCycleDot;
     protected boolean cpuOnBus;
     protected int cpuMCycleDotBase;
     protected int cpuMCycleDotSpan = 4;
@@ -122,7 +122,7 @@ public class GameBoyEmulator implements Emulator, SM83.SystemBus {
     }
 
     protected void runCycle() {
-        this.mcycleDot = 0;
+        this.mCycleDot = 0;
         this.cpuMCycleDotBase = 0;
         this.cpuOnBus = true;
         this.cpu.cycle();
@@ -132,32 +132,32 @@ public class GameBoyEmulator implements Emulator, SM83.SystemBus {
             apuFrameSequencerTick = this.timerController.cycle();
         }
         this.cpu.nextState();
-        this.syncPpuToDot(4);
+        this.syncPPUToDot(4);
         this.apu.cycle(apuFrameSequencerTick);
         this.serialController.cycle();
         this.cartridge.cycle();
         this.bus.cycleOAMDMA();
     }
 
-    protected void syncPpuToDot(int targetDot) {
-        while (this.mcycleDot < targetDot) {
-            this.ppu.cycleDot(this.mcycleDot);
-            this.mcycleDot++;
+    protected void syncPPUToDot(int targetDot) {
+        while (this.mCycleDot < targetDot) {
+            this.ppu.cycleDot(this.mCycleDot);
+            this.mCycleDot++;
         }
     }
 
     // CPU reads latch at the end of the CPU M-cycle: run its dots first
-    void syncPpuForCpuRead() {
+    void syncPPUForCPURead() {
         if (this.cpuOnBus) {
-            this.syncPpuToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan);
+            this.syncPPUToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan);
         }
     }
 
     // CPU writes to PPU registers commit halfway into the CPU M-cycle, so the
     // remaining dots see the new value
-    void syncPpuForCpuPpuRegisterWrite() {
+    void syncPPUForCPUPPURegisterWrite() {
         if (this.cpuOnBus) {
-            this.syncPpuToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan / 2);
+            this.syncPPUToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan / 2);
         }
     }
 

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/GameBoyEmulator.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboy/GameBoyEmulator.java
@@ -24,6 +24,11 @@ public class GameBoyEmulator implements Emulator, SM83.SystemBus {
 
     private final GameBoyCartridge cartridge;
 
+    protected int mcycleDot;
+    protected boolean cpuOnBus;
+    protected int cpuMCycleDotBase;
+    protected int cpuMCycleDotSpan = 4;
+
     public GameBoyEmulator(GameBoyHost host) {
         this.host = host;
 
@@ -117,17 +122,43 @@ public class GameBoyEmulator implements Emulator, SM83.SystemBus {
     }
 
     protected void runCycle() {
+        this.mcycleDot = 0;
+        this.cpuMCycleDotBase = 0;
+        this.cpuOnBus = true;
         this.cpu.cycle();
+        this.cpuOnBus = false;
         boolean apuFrameSequencerTick = false;
         if (this.cpu.getMode() != SM83.Mode.STOPPED) {
             apuFrameSequencerTick = this.timerController.cycle();
         }
         this.cpu.nextState();
-        this.ppu.cycle();
+        this.syncPpuToDot(4);
         this.apu.cycle(apuFrameSequencerTick);
         this.serialController.cycle();
         this.cartridge.cycle();
         this.bus.cycleOAMDMA();
+    }
+
+    protected void syncPpuToDot(int targetDot) {
+        while (this.mcycleDot < targetDot) {
+            this.ppu.cycleDot(this.mcycleDot);
+            this.mcycleDot++;
+        }
+    }
+
+    // CPU reads latch at the end of the CPU M-cycle: run its dots first
+    void syncPpuForCpuRead() {
+        if (this.cpuOnBus) {
+            this.syncPpuToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan);
+        }
+    }
+
+    // CPU writes to PPU registers commit halfway into the CPU M-cycle, so the
+    // remaining dots see the new value
+    void syncPpuForCpuPpuRegisterWrite() {
+        if (this.cpuOnBus) {
+            this.syncPpuToDot(this.cpuMCycleDotBase + this.cpuMCycleDotSpan / 2);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/CGBBus.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/CGBBus.java
@@ -257,10 +257,46 @@ public class CGBBus<E extends GameBoyColorEmulator> extends DMGBus<E> {
         return new byte[8][0x1000];
     }
 
+    public boolean haltCPU() {
+        return this.haltCPU;
+    }
+
+    @Override
+    protected int readByteCartridge(int address) {
+        if (this.enableBootRom && ((address >= 0x0000 && address <= 0x00FF) || (address >= 0x0200 && address <= 0x08FF))) {
+            return SAMEBOY_CGB_BOOT_ROM[address];
+        } else {
+            return this.emulator.getCartridge().readByte(address);
+        }
+    }
+
     @Override
     protected int readWorkRAM(int address) {
         int offset = address & 0x1FFF;
         return (int) this.workRAM[offset < 0x1000 ? 0 : this.workRAMBank][offset & 0xFFF] & 0xFF;
+    }
+
+    @Override
+    protected int readByteIO(int address) {
+        return switch (address) {
+            case KEY_0_ADDR -> this.emulator.readKEY0();
+            case KEY_1_ADDR -> this.emulator.readKEY1();
+            case WBK_ADDR -> this.workRAMBank | 0b11111000;
+            case RP_ADDR -> this.infraredPort | 0b00111100;
+            case UNK_1_ADDR -> this.unknownRegister1;
+            case UNK_2_ADDR -> this.unknownRegister2;
+            case UNK_3_ADDR -> this.emulator.isDMGCompatibilityMode() ? 0xFF : this.unknownRegister3;
+            case UNK_4_ADDR -> this.unknownRegister4 | 0b10001111;
+            case VDMA_1, VDMA_2, VDMA_3, VDMA_4 -> 0xFF;
+            case VDMA_5 -> this.vdmaControl;
+            default -> {
+                if (this.isPPURegisterAddress(address)) {
+                    yield this.emulator.getVideoGenerator().readByte(address);
+                } else {
+                    yield super.readByteIO(address);
+                }
+            }
+        };
     }
 
     @Override
@@ -269,114 +305,69 @@ public class CGBBus<E extends GameBoyColorEmulator> extends DMGBus<E> {
         this.workRAM[offset < 0x1000 ? 0 : this.workRAMBank][offset & 0xFFF] = (byte) value;
     }
 
-    public boolean haltCPU() {
-        return this.haltCPU;
-    }
-
     @Override
-    public int readByte(int address) {
-        if (this.oamTransferInProgress) {
-            return super.readByte(address);
-        } else if (this.enableBootRom && address >= 0x0000 && address <= 0x08FF) {
-            if (address <= 0x00FF) {
-                return SAMEBOY_CGB_BOOT_ROM[address];
-            } else if (address <= 0x01FF) {
-                return super.readByte(address);
-            } else {
-                return SAMEBOY_CGB_BOOT_ROM[address];
+    protected void writeByteIO(int address, int value) {
+        switch (address) {
+            case KEY_0_ADDR -> this.emulator.writeKey0(value);
+            case KEY_1_ADDR -> this.emulator.writeKEY1(value);
+            case WBK_ADDR -> {
+                this.workRAMBank = value & 0b111;
+                if (this.workRAMBank == 0) {
+                    this.workRAMBank = 1;
+                }
             }
-        } else if (address >= IO_START && address <= IO_END) {
-            return switch (address) {
-                case KEY_0_ADDR -> this.emulator.readKEY0();
-                case KEY_1_ADDR -> this.emulator.readKEY1();
-                case WBK_ADDR -> this.workRAMBank | 0b11111000;
-                case RP_ADDR -> this.infraredPort | 0b00111100;
-                case UNK_1_ADDR -> this.unknownRegister1;
-                case UNK_2_ADDR -> this.unknownRegister2;
-                case UNK_3_ADDR -> this.emulator.isDMGCompatibilityMode() ? 0xFF : this.unknownRegister3;
-                case UNK_4_ADDR -> this.unknownRegister4 | 0b10001111;
-                case VDMA_1, VDMA_2, VDMA_3, VDMA_4 -> 0xFF;
-                case VDMA_5 -> this.vdmaControl;
-                default -> {
-                    if (address >= BGPI_ADDR && address <= OPRI_ADDR || address == VBK_ADDR) {
-                        yield this.emulator.getVideoGenerator().readByte(address);
-                    } else {
-                        yield super.readByte(address);
-                    }
-                }
-            };
-        } else {
-            return super.readByte(address);
-        }
-    }
-
-    @Override
-    public void writeByte(int address, int value) {
-        value &= 0xFF;
-        if (this.oamTransferInProgress) {
-            super.writeByte(address, value);
-            return;
-        }
-        if (address >= IO_START && address <= IO_END) {
-            switch (address) {
-                case KEY_0_ADDR -> this.emulator.writeKey0(value);
-                case KEY_1_ADDR -> this.emulator.writeKEY1(value);
-                case WBK_ADDR -> {
-                    this.workRAMBank = value & 0b111;
-                    if (this.workRAMBank == 0) {
-                        this.workRAMBank = 1;
-                    }
-                }
-                case RP_ADDR -> this.infraredPort = (this.infraredPort & 0b10) | (value & 0b11111101);
-                case UNK_1_ADDR -> this.unknownRegister1 = value & 0xFF;
-                case UNK_2_ADDR -> this.unknownRegister2 = value & 0xFF;
-                case UNK_3_ADDR -> this.unknownRegister3 = value & 0xFF;
-                case UNK_4_ADDR -> this.unknownRegister4 = value & 0xFF;
-                case VDMA_1 -> this.vdmaSourceAddress = (((value << 8) & 0xFF00) | (this.vdmaSourceAddress & 0xFF));
-                case VDMA_2 -> this.vdmaSourceAddress = ((this.vdmaSourceAddress & 0xFF00) | (value & 0xF0));
-                case VDMA_3 -> this.vdmaDestinationAddress = (((value << 8) & 0xFF00) | (this.vdmaDestinationAddress & 0xFF));
-                case VDMA_4 -> this.vdmaDestinationAddress = ((this.vdmaDestinationAddress & 0xFF00) | (value & 0xF0));
-                case VDMA_5 -> {
-                    if (this.currentVDMAType != null) {
-                        if ((value & 0x80) != 0) {
-                            this.vdmaControl = value & 0xFF;
-                            this.vdmaControl &= ~0x80;
-                            this.currentVDMAType = VDMAType.HBLANK;
-                            this.vdmaTransferDelay = switch (this.emulator.getCPUSpeed()) {
-                                case DOUBLE_SPEED -> 1;
-                                case SINGLE_SPEED -> 2;
-                            };
-                        } else {
-                            this.vdmaControl = (0x80 | value) & 0xFF;
-                            this.currentVDMAType = null;
-                            this.vdmaTransferInProgress = false;
-                            this.vdmaCopyingBlock = false;
-                            this.oldPpuMode = -1;
-                        }
-                    } else {
+            case RP_ADDR -> this.infraredPort = (this.infraredPort & 0b10) | (value & 0b11111101);
+            case UNK_1_ADDR -> this.unknownRegister1 = value & 0xFF;
+            case UNK_2_ADDR -> this.unknownRegister2 = value & 0xFF;
+            case UNK_3_ADDR -> this.unknownRegister3 = value & 0xFF;
+            case UNK_4_ADDR -> this.unknownRegister4 = value & 0xFF;
+            case VDMA_1 -> this.vdmaSourceAddress = (((value << 8) & 0xFF00) | (this.vdmaSourceAddress & 0xFF));
+            case VDMA_2 -> this.vdmaSourceAddress = ((this.vdmaSourceAddress & 0xFF00) | (value & 0xF0));
+            case VDMA_3 -> this.vdmaDestinationAddress = (((value << 8) & 0xFF00) | (this.vdmaDestinationAddress & 0xFF));
+            case VDMA_4 -> this.vdmaDestinationAddress = ((this.vdmaDestinationAddress & 0xFF00) | (value & 0xF0));
+            case VDMA_5 -> {
+                if (this.currentVDMAType != null) {
+                    if ((value & 0x80) != 0) {
                         this.vdmaControl = value & 0xFF;
                         this.vdmaControl &= ~0x80;
-                        this.currentVDMAType = (value & 0x80) != 0 ? VDMAType.HBLANK : VDMAType.GENERAL;
+                        this.currentVDMAType = VDMAType.HBLANK;
                         this.vdmaTransferDelay = switch (this.emulator.getCPUSpeed()) {
                             case DOUBLE_SPEED -> 1;
                             case SINGLE_SPEED -> 2;
                         };
-                    }
-                }
-                default -> {
-                    if (address >= BGPI_ADDR && address <= OPRI_ADDR || address == VBK_ADDR) {
-                        //if (address != OPRI || this.emulator.getBus().isBootRomEnabled()) {
-                        // TODO: Properly investigate when exactly this applies
-                        this.emulator.getVideoGenerator().writeByte(address, value);
-                        //}
                     } else {
-                        super.writeByte(address, value);
+                        this.vdmaControl = (0x80 | value) & 0xFF;
+                        this.currentVDMAType = null;
+                        this.vdmaTransferInProgress = false;
+                        this.vdmaCopyingBlock = false;
+                        this.oldPpuMode = -1;
                     }
+                } else {
+                    this.vdmaControl = value & 0xFF;
+                    this.vdmaControl &= ~0x80;
+                    this.currentVDMAType = (value & 0x80) != 0 ? VDMAType.HBLANK : VDMAType.GENERAL;
+                    this.vdmaTransferDelay = switch (this.emulator.getCPUSpeed()) {
+                        case DOUBLE_SPEED -> 1;
+                        case SINGLE_SPEED -> 2;
+                    };
                 }
             }
-        } else {
-            super.writeByte(address, value);
+            default -> {
+                if (this.isPPURegisterAddress(address)) {
+                    //if (address != OPRI || this.emulator.getBus().isBootRomEnabled()) {
+                    // TODO: Properly investigate when exactly this applies
+                    this.emulator.getVideoGenerator().writeByte(address, value);
+                    //}
+                } else {
+                    super.writeByteIO(address, value);
+                }
+            }
         }
+    }
+
+    @Override
+    protected boolean isPPURegisterAddress(int address) {
+        return super.isPPURegisterAddress(address) || (address >= BGPI_ADDR && address <= OPRI_ADDR) || address == VBK_ADDR;
     }
 
     // TODO: VDMA bus conflicts with OAM DMA.

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/CGBPPU.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/CGBPPU.java
@@ -37,7 +37,7 @@ public class CGBPPU<E extends GameBoyColorEmulator> extends DMGPPU<E> {
         super(emulator);
     }
 
-    protected int getLcdOffColor() {
+    protected int getLCDOffColor() {
         return 0xFFFFFF;
     }
 

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/GameBoyColorEmulator.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/GameBoyColorEmulator.java
@@ -99,26 +99,33 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
         DMGSerialController<?> serialController = this.getSerialController();
 
         if ((this.key1 & 0x80) == 0) {
+            this.mcycleDot = 0;
+            this.cpuMCycleDotBase = 0;
+            this.cpuMCycleDotSpan = 4;
             boolean apuFrameSequencerTick = false;
             if (bus.haltCPU()) {
                 if (cpu.getMode() != SM83.Mode.STOPPED) {
                     apuFrameSequencerTick = timerController.cycle();
                 }
             } else {
+                this.cpuOnBus = true;
                 cpu.cycle();
+                this.cpuOnBus = false;
                 if (cpu.getMode() != SM83.Mode.STOPPED) {
                     apuFrameSequencerTick = timerController.cycle();
                 }
                 cpu.nextState();
             }
 
-            ppu.cycle();
+            this.syncPpuToDot(4);
             apu.cycle(apuFrameSequencerTick);
             serialController.cycle();
             cartridge.cycle();
             bus.cycleOAMDMA();
             bus.cycleVDMA();
         } else {
+            this.mcycleDot = 0;
+            this.cpuMCycleDotSpan = 2;
             boolean apuFrameSequencerTick = false;
             if (bus.haltCPU()) {
                 if (cpu.getMode() != SM83.Mode.STOPPED) {
@@ -126,20 +133,26 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
                     apuFrameSequencerTick |= timerController.cycle();
                 }
             } else {
+                this.cpuMCycleDotBase = 0;
+                this.cpuOnBus = true;
                 cpu.cycle();
+                this.cpuOnBus = false;
                 if (cpu.getMode() != SM83.Mode.STOPPED) {
                     apuFrameSequencerTick |= timerController.cycle();
                 }
                 cpu.nextState();
 
+                this.cpuMCycleDotBase = 2;
+                this.cpuOnBus = true;
                 cpu.cycle();
+                this.cpuOnBus = false;
                 if (cpu.getMode() != SM83.Mode.STOPPED) {
                     apuFrameSequencerTick |= timerController.cycle();
                 }
                 cpu.nextState();
             }
 
-            ppu.cycle();
+            this.syncPpuToDot(4);
             apu.cycle(apuFrameSequencerTick);
 
             serialController.cycle();

--- a/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/GameBoyColorEmulator.java
+++ b/core/src/main/java/io/github/arkosammy12/jemu/core/nintendo/gameboycolor/GameBoyColorEmulator.java
@@ -91,7 +91,6 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
     @Override
     protected void runCycle() {
         CGBSM83<?> cpu = this.getCpu();
-        CGBPPU<?> ppu = this.getVideoGenerator();
         CGBAPU<?> apu = this.getAudioGenerator();
         GameBoyCartridge cartridge = this.getCartridge();
         CGBBus<?> bus = this.getBus();
@@ -99,7 +98,7 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
         DMGSerialController<?> serialController = this.getSerialController();
 
         if ((this.key1 & 0x80) == 0) {
-            this.mcycleDot = 0;
+            this.mCycleDot = 0;
             this.cpuMCycleDotBase = 0;
             this.cpuMCycleDotSpan = 4;
             boolean apuFrameSequencerTick = false;
@@ -117,14 +116,14 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
                 cpu.nextState();
             }
 
-            this.syncPpuToDot(4);
+            this.syncPPUToDot(4);
             apu.cycle(apuFrameSequencerTick);
             serialController.cycle();
             cartridge.cycle();
             bus.cycleOAMDMA();
             bus.cycleVDMA();
         } else {
-            this.mcycleDot = 0;
+            this.mCycleDot = 0;
             this.cpuMCycleDotSpan = 2;
             boolean apuFrameSequencerTick = false;
             if (bus.haltCPU()) {
@@ -152,7 +151,7 @@ public class GameBoyColorEmulator extends GameBoyEmulator implements CGBSM83.Sys
                 cpu.nextState();
             }
 
-            this.syncPpuToDot(4);
+            this.syncPPUToDot(4);
             apu.cycle(apuFrameSequencerTick);
 
             serialController.cycle();

--- a/core/src/test/resources/gameboy/blargg-expected-failures.txt
+++ b/core/src/test/resources/gameboy/blargg-expected-failures.txt
@@ -1,11 +1,9 @@
 # Blargg ROMs expected to fail. A listed ROM that starts passing fails the
 # suite until it is removed from this list.
 
-# DMG OAM bug
-oam_bug/rom_singles/4-scanline_timing.gb (DMG)
-oam_bug/rom_singles/5-timing_bug.gb (DMG)
+# Die-specific OAM corruption CRC, non-deterministic across DMG units; gate-level
+# simulation also fails it
 oam_bug/rom_singles/7-timing_effect.gb (DMG)
-oam_bug/rom_singles/8-instr_effect.gb (DMG)
 
 # CGB interrupt timing
 interrupt_time/interrupt_time.gb (CGB)

--- a/core/src/test/resources/gameboy/mooneye-expected-failures.txt
+++ b/core/src/test/resources/gameboy/mooneye-expected-failures.txt
@@ -7,8 +7,6 @@ boot_hwio-dmgABCmgb.gb (DMG)
 serial/boot_sclk_align-dmgABCmgb.gb (DMG)
 
 # PPU timing
-ppu/intr_2_mode0_timing_sprites.gb (DMG)
-ppu/intr_2_mode0_timing_sprites.gb (CGB)
 ppu/lcdon_timing-GS.gb (DMG)
 ppu/lcdon_write_timing-GS.gb (DMG)
 


### PR DESCRIPTION
CPU writes hit the PPU mid-M-cycle. To avoid needing to T-cycle step the CPU, the CPU instead progresses the PPU to the appropriate dot when there is memory access. After the CPU has been stepped, the PPU is then stepped however many dots are left to get the full 4 dots per T-cycle.

This is a proof of concept - I've not put effort into ensuring the PPU dot accounting is cleanly modeled within jemu's architecture. The halt IME fix that was reverted has been reapplied here - vblank_stat_intr-GS will not pass on this branch without that change.

Fixes mooneye intr_2_mode0_timing_sprites and blaarg oam_bug tests.